### PR TITLE
Allow for loopback sites

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ robots_path: /srv/robots
 # Default to no local sites to maintain compatibility with existing
 # playbooks.
 nginx_stub_sites: []
+nginx_loopback_sites: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -59,6 +59,13 @@
     dest: "/etc/nginx/conf.d/{{ item.name }}.conf"
   with_items: "{{ nginx_literal_sites }}"
 
+- name: loopback site config
+  template:
+    src: loopback.site.conf.j2
+    dest: "/etc/nginx/conf.d/{{ item.name }}.conf"
+  with_items: "{{ nginx_loopback_sites }}"
+
+
 - name: Add stub site config
   template:
     src: stub.site.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,9 @@
 - include: ssl-selfsign-literal.yml
   sudo: yes
 
+- include: ssl-selfsign-loopback.yml
+  sudo: yes
+
 - include: ssl-selfsign-stub.yml
   sudo: yes
 

--- a/tasks/ssl-selfsign-loopback.yml
+++ b/tasks/ssl-selfsign-loopback.yml
@@ -1,0 +1,22 @@
+---
+- name: SSL loopback cert directory exists
+  file:
+    path: "{{ nginx_cert_path }}/{{ item.name }}"
+    state: directory
+  with_items: nginx_loopback_sites
+- name: SSL loopback key directory exists
+  file:
+    path: "{{ nginx_key_path }}/{{ item.name }}"
+    state: directory
+  with_items: nginx_loopback_sites
+- name: Self-signed loopback cert exists.
+  sudo: yes
+  command: >
+     openssl req -newkey rsa:2048 -nodes -sha256 -x509 
+     -subj "/CN={{ item.name }}" 
+     -days 90 
+     -keyout "{{ nginx_key_path }}"/"{{ item.name }}"/privkey.pem 
+     -out "{{ nginx_cert_path }}"/"{{ item.name }}"/cert.pem
+  args:
+    creates: "{{ nginx_key_path }}/{{ item.name }}/privkey.pem"
+  with_items: nginx_loopback_sites

--- a/templates/loopback.site.conf.j2
+++ b/templates/loopback.site.conf.j2
@@ -1,0 +1,62 @@
+{% for upstream in item.upstreams %}
+upstream {{ upstream.name }} {
+{% for port in upstream.ports %}
+  server             127.0.0.1:{{ port }};
+}
+{% endfor %}
+{% endfor %}
+
+server {
+  listen              80;
+  server_name         {{ item.name }};
+
+  # Let's Encrypt CertBot
+  location /.well-known/acme-challenge {
+    alias {{ certbot_path }}/.well-known/acme-challenge;
+  }
+
+  # root
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen              443;
+  server_name         {{ item.name }};
+
+  ssl                 on;
+  ssl_certificate     {{ nginx_cert_path }}/{{ item.name }}/cert.pem;
+  ssl_certificate_key {{ nginx_key_path }}/{{ item.name }}/privkey.pem;
+
+  access_log          /var/log/nginx/{{ item.name }}.access.log;
+
+  # Global Proxy settings for this server_name
+  proxy_set_header    Host $host;
+  proxy_set_header    X-Real-IP $remote_addr;
+  proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header    X-Forwarded-Proto $scheme;
+  proxy_cache_valid 200 301 302 401 403 404 5m;
+  proxy_cache_bypass $no_cache $http_cache_control;
+  proxy_cache_revalidate  on;
+  proxy_cache cache;
+
+{% if item.robots == "disallow" %}
+  # robots.txt overlay
+  location =/robots.txt {
+    alias             /srv/robots/robots.disallow.txt;
+  }
+{% elif item.robots == "dspace" %}
+  # robots.txt overlay
+  location =/robots.txt {
+    alias             /srv/robots/robots.dspace.txt;
+  }
+{% endif %}
+
+  # root
+  location / {
+    # Make sure we keep this nginx setting intact
+    add_header        X-Content-Type-Options nosniff;
+    proxy_pass        http://{{ item.upstreams.0.name }}/;
+  }
+}


### PR DESCRIPTION
Add the ability to specify backend bound to 127.0.0.1 at various ports. 

Motivation and Context
----------------------
Need to allow for loopback sites so we can us nginx as an ssl wrapper

How Has This Been Tested?
-------------------------
Successful provision of Solr backend. 