### PR TITLE
Add hostname, upstream, and other log enrichment to site access logs

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -21,9 +21,9 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main '$time_iso8601 $hostname nginx $remote_addr - $remote_user [$time_local] $server_name "$request" $request_time'
+                      '$status $body_bytes_sent "$upstream_addr" "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"'; 
 
     access_log  /var/log/nginx/access.log  main;
 

--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -31,7 +31,7 @@ server {
   ssl                 on;
   ssl_certificate     {{ nginx_cert_path }}/{{ nginx_site.cert_name | default(nginx_site.name) }}/fullchain.pem;
   ssl_certificate_key {{ nginx_key_path }}/{{ nginx_site.cert_name | default(nginx_site.name) }}/privkey.pem;
-  access_log          /var/log/nginx/{{ nginx_site.name }}.access.log;
+  access_log          /var/log/nginx/{{ nginx_site.name }}.access.log main;
   error_log          /var/log/nginx/{{ nginx_site.name }}.error.log;
 
   # Global Proxy settings for this server_name


### PR DESCRIPTION
Enrich NGINX access logs

Adding timestamp, hostname, service, nginx_server_name (website host), and upstream IP address to NGINX access logs. 

Motivation and Context
----------------------
This has become more and more necessary for troubleshooting web issues and utilizing Elasticsearch or other log analytics platforms. 

How Has This Been Tested?
-------------------------
Tested on test load-balancer/reverse proxy and verified on production, as well as log ingestion into Elasticsearch. 
