### PR TITLE
Fix spacing issue and add PID

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -21,8 +21,8 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main '$time_iso8601 $hostname nginx $remote_addr - $remote_user [$time_local] $server_name "$request" $request_time'
-                      '$status $body_bytes_sent "$upstream_addr" "$http_referer" '
+    log_format  main '$time_iso8601 $hostname nginx[$pid] $remote_addr - $remote_user [$time_local] $server_name "$request" $request_time'
+                      ' $status $body_bytes_sent "$upstream_addr" "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"'; 
 
     access_log  /var/log/nginx/access.log  main;


### PR DESCRIPTION
Add space prior to $status field, also add PID to the nginx field to create a psuedo-syslog format

Motivation and Context
----------------------
Allows consistent logging and log parsing for Elasticsearch 

How Has This Been Tested?
-------------------------
lb-blue.devops.ec2.internal
lb-test.test.devops.ec2.internal
