### PR TITLE
Include $scheme and $server_port in main logs.

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -20,8 +20,7 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-
-    log_format  main '$time_iso8601 $hostname nginx[$pid] $remote_addr - $remote_user [$time_local] $server_name "$request" $request_time'
+    log_format  main '$time_iso8601 $hostname nginx[$pid] $remote_addr - $remote_user [$time_local] $scheme $server_name $server_port "$request" $request_time'
                       ' $status $body_bytes_sent "$upstream_addr" "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"'; 
 


### PR DESCRIPTION
Include $scheme and $server_port in main log format. 

Motivation and Context
----------------------
In some cases, we need to be able to differentiate between ssl and non ssl requests for debugging. 

How Has This Been Tested?
-------------------------
Config copied from production. 