### PR TITLE
Pull out DSpace specific config

### DIFF
--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -55,30 +55,16 @@ server {
   location =/robots.txt {
     alias             /srv/robots/robots.disallow.txt;
   }
-{% elif nginx_site.robots == "dspace" %}
 
-  # dspace robots.txt overlay
-  location =/robots.txt {
-    alias             /srv/robots/robots.dspace.txt;
-  }
 {% elif nginx_site.robots == "repox" %}
 
-  # dspace robots.txt overlay
+  # repox robots.txt overlay
   location =/robots.txt {
     alias             /srv/robots/robots.repox.txt;
   }
 {% endif %}
 {% endif %}
-{% if (nginx_site.app_config is defined) %}
-{% if nginx_site.app_config == "dspace" %}
 
-  # Temporarily disable part of dspace API because of DS-3250
-  # https://jira.duraspace.org/browse/DS-3250
-  location /rest/api/items/find-by-metadata-field {
-    return 403;
-  }
-{% endif %}
-{% endif %}
 {% if (nginx_site.redirects is defined) %}
 {% for redirect in nginx_site.redirects %}
 
@@ -92,24 +78,6 @@ server {
 {% for upstream in nginx_site.upstreams %}
 
   # {{ upstream.name }}
-{% if (nginx_site.app_config is defined) %}
-{% if nginx_site.app_config == "dspace" %}
-  # dspace leaks cookies, which we have to squash to cache theme assets
-  location ~* ^(/themes/)|(/static/).+\.(jpg|jpeg|gif|png|bmp|ico|css|js)$ {
-
-    # Mitigate Major DSpace security vulnerability affecting all XMLUI sites
-    rewrite ^/+themes/.*:.*$ /error permanent;
-
-    ## Plug the cookie leak
-    proxy_ignore_headers "Set-Cookie";
-    proxy_hide_header "Set-Cookie";
-
-    ## Make sure we keep this nginx setting intact
-    add_header X-Content-Type-Options nosniff;
-    proxy_pass          http{% if upstream.secure|default(true) %}s{% endif %}://{{ upstream.name }};
-  }
-{% endif %}
-{% endif %}
 {% for location in upstream.locations %}
 
   # {{ location.location_match }}


### PR DESCRIPTION


Much of the DSpace specific configuration is redundant or no longer needed, we can break this out and use them in an include file

Motivation and Context
----------------------
Much of the DSpace specific configuration is redundant or no longer needed 

How Has This Been Tested?
-------------------------
Tested on a DSpace6 Test enviornment 
