### PR TITLE
Handle folder/file permissions better.

### DIFF
--- a/tasks/assets-certs.yml
+++ b/tasks/assets-certs.yml
@@ -4,18 +4,8 @@
   file:
     path: "{{ nginx_key_path }}/{{ item  }}"
     state: directory
-    recurse: yes
-    mode: 0755
-    owner: nginx
-    group: wheel
-
-- name: TLS cert directory exists
-  file:
-    path: "{{ nginx_cert_path }}/{{ item  }}"
-    state: directory
-    recurse: yes
-    mode: 0755
-    owner: nginx
+    mode: 0750
+    owner: root
     group: wheel
 
 - name: Push TLS private key
@@ -24,6 +14,14 @@
       {{ lookup('file', tls_cert_path + '/' + item  + '/privkey.vault.yml') }}
     dest: "{{ nginx_key_path }}/{{ item  }}/privkey.pem"
     mode: 0640
+    owner: root
+    group: wheel
+
+- name: TLS cert directory exists
+  file:
+    path: "{{ nginx_cert_path }}/{{ item  }}"
+    state: directory
+    mode: 0755
     owner: root
     group: wheel
 


### PR DESCRIPTION
Reorder for clarity, and don't recurse unnecessarily when setting folder permissions. This should fix flip-flop of cert file permissions. 


