### PR TITLE
Fix some file state flip-flops in role.

### DIFF
--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -7,7 +7,6 @@
     mode: 0755
     owner: root
     group: wheel
-    recurse: yes
 
 - name: files to robots directory
   copy:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,7 +25,6 @@
   file:
     path: "{{ nginx_acme_challenge_dir }}/.well-known/acme-challenge"
     state: directory
-    recurse: yes
     mode: 0775
     owner: nginx
     group: wheel

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -7,14 +7,7 @@
     baseurl: http://nginx.org/packages/centos/7/$basearch/
     gpgkey: http://nginx.org/packages/keys/nginx_signing.key
     gpgcheck: yes
-
-- name: Nginx repository has priority
-  ini_file:
-    dest: /etc/yum.repos.d/nginx.repo
-    section: nginx
-    option: priority
-    value: 2
-    backup: yes
+    priority: 2
 
 - name: Install yum packages
   yum:


### PR DESCRIPTION
* Configure nginx repo priority directly to keep Ansible from thinking
  that it needs to redo the repo file for nginx.
* Don't set recursive permissions on folders. It makes the permissions
  of their contents always change.



