### PR TITLE
Add large headers setting to allow for big cookies.

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -65,6 +65,9 @@ http {
     ## Let us upload reasonably large files.
     client_max_body_size 64M;
 
+    ## Set higher limit to account for cookies set in .ou.edu domain
+    large_client_header_buffers 4 16k;
+
     index   index.html index.htm;
 
     ## No reason to tell the world what we've got in our back pocket.


### PR DESCRIPTION
Set higher limit to for `large_client_header_buffers ` tp account for larger cookies that are being set under the `.ou.edu` domain. 

Motivation and Context
----------------------

Our version of nginx uses a particularly low value, and we have to take it up a couple of notches because of occuspace and other cookies. 

How Has This Been Tested?
-------------------------
Verified in test and currently running in prod. 
