### PR TITLE
set systemd tasks inside task block and add conditional to task block

### DIFF
--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,20 +1,21 @@
 ---
 
-- name: Copy custom systemd service file for nginx
-  template:
-    src: 00-RequireMountsFor.service.j2
-    dest: /etc/systemd/system/nginx.service.d/00-RequireMountsFor.service
-    mode: 0644
-    owner: root
-    group: root
-  when: nginx_RequireMountsFor | default(None)
+- block:
+  - name: Copy custom systemd service file for nginx
+    template:
+      src: 00-RequireMountsFor.service.j2
+      dest: /etc/systemd/system/nginx.service.d/00-RequireMountsFor.service
+      mode: 0644
+      owner: root
+      group: root
     
-- name: Set SELinux context for nginx.service
-  shell: |
-    semanage fcontext -a -t httpd_unit_file_t "/etc/systemd/system/nginx.service.d(/.*)?"
-    restorecon -rv "/etc/systemd/system/nginx.service.d"
+  - name: Set SELinux context for nginx.service
+    shell: |
+      semanage fcontext -a -t httpd_unit_file_t "/etc/systemd/system/nginx.service.d(/.*)?"
+      restorecon -rv "/etc/systemd/system/nginx.service.d"
 
-- name: Do systemd daemon-reload to pick up config changes
-  systemd:
-    daemon_reload: yes
-    name: nginx
+  - name: Do systemd daemon-reload to pick up config changes
+    systemd:
+      daemon_reload: yes
+      name: nginx
+  when: nginx_RequireMountsFor | default(None)


### PR DESCRIPTION
<!--- Replace this with the title of your PR, or specify the title above and delete this line-->

<!--- Replace this with a detailed description of your changes -->
This PR sets all of the `systemd.yml` tasks inside of a task block and sets the `when nginx_RequireMountsFor` condition against the entire block of tasks. This makes sure that none of these tasks are executed unless the `nginx_RequireMountsFor` condition is set.


Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
When running this role against target instances that don't have the `nginx_RequireMountsFor` variable set, the role will cause playbooks to fail. This failure is caused by the SELinux task in `systemd.yml` that attempts to set the context against a file that doesn't exist. In order for this role to run properly in playbooks, the `when nginx_RequireMountsFor` condition needs to be set for the SELinux task as well.

Since the task that reloads the systemd daemon doesn't need to be performed either unless the above tasks have been performed, this task was included inside the tasks block against which the condition is set.

<!--- If it relates to an open issue or another pull request, please link to that here. -->

How Has This Been Tested?
-------------------------

This change has been tested against the test load balancer (since it met the condition of an instance where the `nginx_RequireMountsFor` variable isn't set. When running a playbook that includes this role, all of the tasks in `systemd.yml` were skipped and the playbook didn't fail. 

