### PR TITLE
Make config dir before using it.

### DIFF
--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,7 +1,15 @@
 ---
 
 - block:
-  - name: Copy custom systemd service file for nginx
+
+  - name: Make space custom systemd config for nginx
+    file: 
+      path: /etc/systemd/system/nginx.service.d/
+      state: directory
+      owner: root
+      group: root
+
+  - name: Copy systemd config to allow nginx startup to wait on fs mounts
     template:
       src: 00-RequireMountsFor.service.j2
       dest: /etc/systemd/system/nginx.service.d/00-RequireMountsFor.service


### PR DESCRIPTION
Quick bugfix. We have to make our systemd config dir for nginx before adding files to it. 